### PR TITLE
ci: add staging deploy trigger on lockfile changes

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,30 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+
+permissions: {}
+
+jobs:
+  trigger-deploy:
+    name: Trigger Staging Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to barazo-deploy
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ secrets.DEPLOY_PAT }}
+          repository: barazo-forum/barazo-deploy
+          event-type: deploy-staging
+          client-payload: |
+            {
+              "trigger_repo": "barazo-workspace",
+              "api_ref": "main",
+              "web_ref": "main"
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 /barazo-website/
 
 # Org-level .github repo (independently tracked)
-/.github/
+# Allow .github/workflows/ in this repo for CI triggers
+/.github/*
+!/.github/workflows/
 
 # Claude Code (private per-machine)
 CLAUDE.md


### PR DESCRIPTION
## Summary

- Fires `repository_dispatch` to `barazo-deploy` when workspace root files change (lockfile, catalogs, package.json)
- Ensures staging builds always use the latest dependency resolution
- Only triggers on changes to `pnpm-lock.yaml`, `pnpm-workspace.yaml`, or `package.json`
- Also updates `.gitignore` to allow `.github/workflows/` (previously blocked by org `.github/` ignore)

## Test plan

- [ ] CI passes
- [ ] Dependabot merge in workspace triggers staging deploy