### PR TITLE
ci: add dependency freshness check

### DIFF
--- a/.github/workflows/dependency-freshness.yml
+++ b/.github/workflows/dependency-freshness.yml
@@ -1,0 +1,134 @@
+name: Dependency Freshness Check
+
+on:
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  pull_request:
+    paths:
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-outdated:
+    name: Check Outdated Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      # Fetch workspace member package.json files (needed for pnpm outdated -r)
+      - name: Fetch workspace member manifests
+        run: |
+          for pkg in barazo-api barazo-web barazo-lexicons; do
+            mkdir -p "$pkg"
+            curl -sL "https://raw.githubusercontent.com/barazo-forum/$pkg/main/package.json" \
+              -o "$pkg/package.json"
+          done
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run pnpm outdated
+        id: outdated
+        run: |
+          set +e
+          OUTPUT=$(pnpm outdated -r --format json 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          # pnpm outdated exits 1 when packages are outdated (not an error)
+          if [ $EXIT_CODE -eq 1 ]; then
+            echo "has_outdated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_outdated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Save raw JSON for processing
+          echo "$OUTPUT" > /tmp/outdated-raw.json
+
+          # Build markdown summary
+          {
+            echo "## Dependency Freshness Report"
+            echo ""
+            echo "Generated: $(date -u '+%Y-%m-%d %H:%M UTC')"
+            echo ""
+
+            if [ "$EXIT_CODE" -eq 0 ]; then
+              echo "All dependencies are up to date."
+            else
+              echo "| Package | Current | Latest | Type | Workspace |"
+              echo "|---------|---------|--------|------|-----------|"
+
+              # Parse JSON output into markdown table
+              echo "$OUTPUT" | python3 -c "
+          import json, sys
+          try:
+              data = json.load(sys.stdin)
+              for pkg_name, info in sorted(data.items()):
+                  current = info.get('current', '?')
+                  latest = info.get('latest', '?')
+                  dep_type = info.get('dependencyType', '?')
+                  # Determine which workspace package
+                  belongs_to = info.get('belongsTo', '.')
+                  if belongs_to == '.':
+                      belongs_to = 'root'
+                  print(f'| \`{pkg_name}\` | {current} | {latest} | {dep_type} | {belongs_to} |')
+          except json.JSONDecodeError:
+              print('Could not parse pnpm outdated output.')
+          "
+              echo ""
+              echo "### Known exceptions"
+              echo ""
+              echo "These packages are intentionally held back (see \`standards/shared.md\` Version Exceptions):"
+              echo ""
+              echo "| Package | Held at | Reason |"
+              echo "|---------|---------|--------|"
+              echo "| \`eslint\` | 9.x | Ecosystem not ready (typescript-eslint, eslint-config-next) |"
+              echo "| \`isomorphic-dompurify\` | 2.x | No stable v3 release |"
+            fi
+          } > /tmp/outdated-report.md
+
+          # Also write to step summary
+          cat /tmp/outdated-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      # On PRs: post as a comment
+      - name: Comment on PR
+        if: github.event_name == 'pull_request' && steps.outdated.outputs.has_outdated == 'true'
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: dependency-freshness
+          path: /tmp/outdated-report.md
+
+      # On schedule/dispatch: create or update a tracking issue
+      - name: Update tracking issue
+        if: github.event_name != 'pull_request' && steps.outdated.outputs.has_outdated == 'true'
+        run: |
+          ISSUE=$(gh issue list --label "dependencies" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$ISSUE" ]; then
+            gh issue create \
+              --title "Outdated dependencies" \
+              --label "dependencies" \
+              --body-file /tmp/outdated-report.md
+          else
+            gh issue comment "$ISSUE" --body-file /tmp/outdated-report.md
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Weekly scheduled workflow (Monday 08:00 UTC) runs `pnpm outdated -r` across all workspace members
- On PRs that change dependency files: posts a sticky comment with outdated packages
- On schedule/dispatch: creates or updates a GitHub issue labeled "dependencies"
- Reports known exceptions (eslint 9.x, isomorphic-dompurify 2.x) alongside results
- Always writes a job summary regardless of trigger type

Implements the deferred item from `plans/2026-02-16-dependency-audit.md`:
> **Item deferred:** `pnpm outdated` CI check was not added. Can be done separately.

Also fulfills `standards/shared.md` "CI Dependency Freshness Check" section.

## Test plan
- [ ] CI passes
- [ ] Manual trigger via `workflow_dispatch` produces expected output