### PR TITLE
ci: add automatic lockfile sync for sub-repo dependency updates

### DIFF
--- a/.github/workflows/sync-lockfile.yml
+++ b/.github/workflows/sync-lockfile.yml
@@ -1,0 +1,61 @@
+name: Sync Lockfile
+
+on:
+  repository_dispatch:
+    types: [sync-lockfile]
+  schedule:
+    # Every 6 hours -- catches Dependabot merges in sub-repos
+    - cron: "0 */6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Regenerate workspace lockfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+
+      - name: Fetch workspace member manifests
+        run: |
+          for pkg in barazo-api barazo-web barazo-lexicons; do
+            mkdir -p "$pkg"
+            curl -sfL "https://raw.githubusercontent.com/barazo-forum/$pkg/main/package.json" \
+              -o "$pkg/package.json"
+          done
+
+      - name: Regenerate lockfile
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Check for lockfile changes
+        id: diff
+        run: |
+          if git diff --quiet pnpm-lock.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Lockfile is already up to date."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Lockfile has changed -- needs update."
+            git diff --stat pnpm-lock.yaml
+          fi
+
+      - name: Commit lockfile to main
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml
+          git commit -m "fix(deps): auto-sync lockfile with sub-repo dependencies"
+          git push origin main


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Action (`sync-lockfile.yml`) that regenerates the workspace root lockfile every 6 hours
- Fetches the latest `package.json` from barazo-api, barazo-web, and barazo-lexicons, runs `pnpm install`, and auto-commits if the lockfile changed
- Also supports `repository_dispatch` (type: `sync-lockfile`) and manual trigger
- Prevents the deploy breakage we hit today when Dependabot updated barazo-api deps without syncing the workspace lockfile

## How it works
1. Dependabot merges a dep bump in a sub-repo (e.g., barazo-api)
2. Within 6 hours, this workflow detects the lockfile drift
3. Regenerates and auto-commits the updated lockfile to main
4. Next deploy picks up the synced lockfile and succeeds

## Test plan
- [ ] Trigger manually via `gh workflow run sync-lockfile.yml` after merge
- [ ] Verify it detects no changes (lockfile is currently up to date)
- [ ] Next time Dependabot merges in a sub-repo, verify the lockfile auto-syncs within 6h