### PR TITLE
fix(ci): always deploy after lockfile sync, forward refs from sub-repos

### DIFF
--- a/.github/workflows/sync-lockfile.yml
+++ b/.github/workflows/sync-lockfile.yml
@@ -16,6 +16,27 @@ jobs:
     name: Regenerate workspace lockfile
     runs-on: ubuntu-latest
     steps:
+      # ------------------------------------------------------------------
+      # Determine deploy refs from dispatch payload, or default to main
+      # ------------------------------------------------------------------
+      - name: Determine deploy refs
+        id: refs
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "trigger=${{ github.event.client_payload.trigger_repo || 'barazo-workspace' }}" >> "$GITHUB_OUTPUT"
+            echo "api_ref=${{ github.event.client_payload.api_ref || 'main' }}" >> "$GITHUB_OUTPUT"
+            echo "web_ref=${{ github.event.client_payload.web_ref || 'main' }}" >> "$GITHUB_OUTPUT"
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "trigger=${{ github.event_name }}" >> "$GITHUB_OUTPUT"
+            echo "api_ref=main" >> "$GITHUB_OUTPUT"
+            echo "web_ref=main" >> "$GITHUB_OUTPUT"
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ------------------------------------------------------------------
+      # Regenerate the workspace lockfile
+      # ------------------------------------------------------------------
       - name: Checkout workspace
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -59,8 +80,13 @@ jobs:
           git commit -m "fix(deps): auto-sync lockfile with sub-repo dependencies"
           git push origin main
 
-      - name: Trigger staging re-deploy
-        if: steps.diff.outputs.changed == 'true'
+      # ------------------------------------------------------------------
+      # Trigger staging deploy
+      # - Always deploy when dispatched by a sub-repo (PR merge)
+      # - Only deploy on schedule/manual if the lockfile actually changed
+      # ------------------------------------------------------------------
+      - name: Trigger staging deploy
+        if: steps.refs.outputs.deploy == 'true' || steps.diff.outputs.changed == 'true'
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.DEPLOY_PAT }}
@@ -68,7 +94,7 @@ jobs:
           event-type: deploy-staging
           client-payload: |
             {
-              "trigger_repo": "barazo-workspace",
-              "api_ref": "main",
-              "web_ref": "main"
+              "trigger_repo": "${{ steps.refs.outputs.trigger }}",
+              "api_ref": "${{ steps.refs.outputs.api_ref }}",
+              "web_ref": "${{ steps.refs.outputs.web_ref }}"
             }


### PR DESCRIPTION
## Summary

- Sync-lockfile workflow now accepts deploy refs (`trigger_repo`, `api_ref`, `web_ref`) from the dispatch payload and forwards them to the deploy workflow
- Always triggers a deploy when dispatched by a sub-repo PR merge, even when the lockfile hasn't changed (code-only changes)
- Still only deploys on schedule/manual when the lockfile actually changed

Counterpart to barazo-forum/barazo-web#157 and barazo-forum/barazo-api#132.

## Context

PR merges in barazo-web/api previously dispatched both a deploy AND a lockfile sync in parallel. When a PR added new dependencies, the deploy would start with the stale workspace lockfile and fail with `ERR_PNPM_OUTDATED_LOCKFILE`. The sync would update it later, but no re-deploy was triggered (the dispatch to barazo-workspace was silently failing due to PAT permissions, and even if it worked there was a race condition).

The new flow: **sub-repo PR merge -> sync lockfile -> deploy**. Serial, no race.

## Test plan

- [ ] Merge workspace PR first
- [ ] Merge web or API PR, verify deploy succeeds
- [ ] Merge a PR with no dependency changes, verify deploy still triggers