### PR TITLE
fix(deps): regenerate lockfile with latest sub-repo dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@atproto/tap':
         specifier: 0.2.7
         version: 0.2.7
+      '@barazo/plugin-signatures':
+        specifier: link:../barazo-plugins/packages/plugin-signatures
+        version: link:../barazo-plugins/packages/plugin-signatures
       '@fastify/cookie':
         specifier: 11.0.2
         version: 11.0.2


### PR DESCRIPTION
## Summary
- Regenerated `pnpm-lock.yaml` by fetching latest `package.json` from each sub-repo's `main` branch
- Unblocks staging deploys that were failing due to stale lockfile
- The missing dependency is `@barazo/plugin-signatures` (workspace link added to barazo-api)