### PR TITLE
fix(deps): add forceLegacyDeploy for pnpm deploy with link dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,10 @@ packages:
   - "barazo-web"
   - "barazo-plugins"
 
+# Required for pnpm deploy with link: dependencies across workspace members.
+# See https://pnpm.io/cli/deploy
+forceLegacyDeploy: true
+
 catalog:
   zod: "^4.3.6"
   vitest: "^4.0.18"


### PR DESCRIPTION
## Summary
- Add `forceLegacyDeploy: true` to `pnpm-workspace.yaml`
- Fixes `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` during `pnpm deploy` when resolving `link:` dependencies across workspace members (specifically `@barazo/plugin-signatures`)
- This is a known pnpm issue where the new deploy algorithm doesn't handle cross-workspace `link:` deps correctly

## Test plan
- [ ] CI passes
- [ ] Staging deploy succeeds after merge