### PR TITLE
fix(deps): add @types/react to plugin-signatures for Docker build

### DIFF
--- a/barazo-plugins/packages/plugin-signatures/package.json
+++ b/barazo-plugins/packages/plugin-signatures/package.json
@@ -8,11 +8,11 @@
   "exports": {
     "./plugin.json": "./plugin.json",
     "./backend/*": "./dist/backend/*.js",
-    "./frontend/*": "./dist/frontend/*.js",
-    "./frontend/register": "./dist/frontend/register.js",
-    "./frontend/CommunitySignatureField": "./dist/frontend/CommunitySignatureField.js",
-    "./frontend/DefaultSignatureField": "./dist/frontend/DefaultSignatureField.js",
-    "./frontend/PostSignature": "./dist/frontend/PostSignature.js"
+    "./frontend/register": "./frontend/register.ts",
+    "./frontend/CommunitySignatureField": "./frontend/CommunitySignatureField.tsx",
+    "./frontend/DefaultSignatureField": "./frontend/DefaultSignatureField.tsx",
+    "./frontend/PostSignature": "./frontend/PostSignature.tsx",
+    "./frontend/*": "./dist/frontend/*.js"
   },
   "files": [
     "dist",
@@ -22,6 +22,10 @@
     "build": "tsc",
     "build:backend": "tsc -p tsconfig.backend.json",
     "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3"
   },
   "peerDependencies": {
     "fastify": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,13 @@ importers:
       zod:
         specifier: ^4.0.0
         version: 4.3.6
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
 
   barazo-web:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `@types/react` and `@types/react-dom` as devDependencies to `@barazo/plugin-signatures`
- Syncs the tracked plugin `package.json` copy with current barazo-plugins main
- Regenerates workspace lockfile

## Context
The Docker build fails because Turbopack's `transpilePackages` still type-checks plugin source files during the Next.js build. In Docker's pnpm strict isolation, `@types/react` installed for `barazo-web` isn't accessible to the plugin package. This causes: `Could not find a declaration file for module 'react'`.

Adding `@types/react` as a devDependency of the plugin ensures it's installed in Docker and available during the build.

## Test plan
- [ ] Docker build succeeds (no more React type errors)
- [ ] Staging deploy completes
- [ ] Signature fields visible on `/settings` when plugin enabled