### PR TITLE
feat: add Task issue template for non-code work

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,44 @@
+name: Task
+description: A non-code task (website, email, grant, design, infrastructure, etc.)
+labels: ["task", "triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What needs to be done?
+      description: Describe the task clearly.
+      placeholder: Set up a transactional email provider for...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Website
+        - Content & Copy
+        - Email & Comms
+        - Legal & Grants
+        - Design
+        - Infrastructure
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context & references
+      description: Links, screenshots, or background information.
+    validations:
+      required: false
+
+  - type: input
+    id: deadline
+    attributes:
+      label: Deadline (if any)
+      description: Leave blank if no hard deadline.
+      placeholder: "2026-04-01"
+    validations:
+      required: false

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Allow .github/workflows/ in this repo for CI triggers
 /.github/*
 !/.github/workflows/
+!/.github/ISSUE_TEMPLATE/
 
 # Claude Code (private per-machine)
 CLAUDE.md


### PR DESCRIPTION
## Summary
- Adds a "Task" issue template for non-code work (website setup, emails, grants, design, infrastructure, etc.)
- Category dropdown: Website, Content & Copy, Email & Comms, Legal & Grants, Design, Infrastructure, Other
- Updates `.gitignore` to allow `.github/ISSUE_TEMPLATE/`