### PR TITLE
docs(agents): add git worktrees requirement and pre-work validation check

### DIFF
--- a/agents-md/shared.md
+++ b/agents-md/shared.md
@@ -19,9 +19,35 @@ Open-source forum software built on the [AT Protocol](https://atproto.com/). Por
 7. **No raw SQL** -- Drizzle ORM with parameterized queries only.
 8. **Structured logging** -- Pino logger, never `console.log`.
 
+### Before Starting Any Issue
+
+**Always check for existing work before implementing anything:**
+
+1. Search for open PRs that may already address the issue: `gh pr list --repo singi-labs/<repo> --state open`
+2. Search for related branches: `gh api repos/singi-labs/<repo>/branches --paginate`
+3. Scan the codebase for partial implementations of the feature
+4. Check closed PRs for previously attempted work
+
+The GitHub board may lag behind actual implementation state. Partial or complete implementations may exist without being reflected in issue status. Never duplicate work -- always verify first.
+
 ### Git Workflow
 
 All changes go through Pull Requests -- never commit directly to `main`. Branch naming: `type/short-description` (e.g., `feat/add-reactions`, `fix/xss-sanitization`).
+
+**Use git worktrees for all feature work.** Each branch must get its own working directory. This prevents multiple agents from stepping on each other's files and allows parallel work without stashing.
+
+```bash
+# Create a worktree for your branch
+git worktree add /tmp/<repo>-<branch-name> -b <branch-name> origin/main
+
+# Work in the worktree
+cd /tmp/<repo>-<branch-name>
+
+# When done, remove the worktree
+git worktree remove /tmp/<repo>-<branch-name>
+```
+
+Never work directly in the main checkout (`/singi-labs/repos/<repo>/`). Always create a worktree per issue. Clean up the worktree after the PR is merged.
 
 ### AT Protocol Context
 


### PR DESCRIPTION
## Summary

- Adds **"Before Starting Any Issue"** section to shared AGENTS.md: agents must check for open PRs, related branches, and partial implementations before starting any work. The GitHub board may lag actual implementation state.
- Adds **git worktrees requirement** to Git Workflow section: all feature work must use a separate worktree per branch. Prevents multiple agents from stepping on each other's files.

## Context

- Resolves [BARA-11](/BARA/issues/BARA-11): several issues (GH#68, #38, #77, #39) already had open PRs that were not reflected in issue status.
- Resolves [BARA-15](/BARA/issues/BARA-15): agents working on the same repo without worktrees risk file conflicts.

## After merge

The `sync-agents-md` GitHub Action will automatically push the updated AGENTS.md to all repos.

Co-Authored-By: Paperclip <noreply@paperclip.ing>