### PR TITLE
docs(agents-md): prohibit AI tool attribution in commits and PRs

### DIFF
--- a/agents-md/repos/barazo-api.md
+++ b/agents-md/repos/barazo-api.md
@@ -40,3 +40,65 @@ The AppView backend for Barazo. Subscribes to AT Protocol firehose, indexes `for
 - GlitchTip error monitoring from first deployment
 - No raw SQL -- Drizzle ORM with parameterized queries only
 - Accessible error responses -- include human-readable messages and structured error codes to support accessible frontend rendering
+
+## Local Development & Testing Infrastructure
+
+Shared dev infrastructure is available for running tests, builds, and local dev.
+
+### Database Access
+
+- **PostgreSQL 16**: host `singi-labs-postgres-1`, port `5432`, user `singi`, password `singi-dev`
+  - `barazo_dev` -- for local dev server
+  - `barazo_test` -- for test runs (wiped between test suites)
+- **Valkey 8**: host `singi-labs-valkey-1`, port `6379` (no auth)
+
+### Environment Setup
+
+Create a `.env` file in the repo CWD before running tests or dev:
+
+```env
+# /singi-labs/repos/barazo-api/.env
+DATABASE_URL=postgres://singi:singi-dev@singi-labs-postgres-1:5432/barazo_dev
+VALKEY_URL=redis://singi-labs-valkey-1:6379
+```
+
+For integration tests, use `barazo_test` to avoid polluting dev data:
+
+```env
+DATABASE_URL=postgres://singi:singi-dev@singi-labs-postgres-1:5432/barazo_test
+VALKEY_URL=redis://singi-labs-valkey-1:6379
+```
+
+### First-Time Setup
+
+Before running any commands, install dependencies (only needed once -- `node_modules` persists across heartbeats):
+
+```sh
+pnpm install
+```
+
+### Available Commands
+
+- `pnpm lint` -- ESLint
+- `pnpm typecheck` -- TypeScript strict check
+- `pnpm build` -- compile
+- `pnpm test` -- unit tests (Vitest)
+- `pnpm test:integration` -- integration tests (needs `DATABASE_URL` + `VALKEY_URL`)
+- `pnpm test:coverage` -- unit tests with coverage report
+
+### Mandatory Before Pushing
+
+Every agent MUST run this before pushing a branch:
+
+```sh
+pnpm lint && pnpm typecheck && pnpm build && pnpm test
+```
+
+Fix failures before pushing. Never push broken code.
+
+### VPS Access
+
+Agents can SSH to the staging server for deployment and debugging:
+
+- `ssh barazo-staging` -- connects as deploy user
+- No passwordless sudo on staging -- use for docker commands and log inspection only

--- a/agents-md/repos/barazo-web.md
+++ b/agents-md/repos/barazo-web.md
@@ -38,3 +38,65 @@ The default frontend for Barazo forums. Communicates with the AppView backend ex
 - Radix primitives (via shadcn/ui) for complex interactive components -- no custom dropdowns, dialogs, etc.
 - SEO -- JSON-LD structured data (DiscussionForumPosting, BreadcrumbList), OpenGraph + Twitter Cards, sitemaps, canonical URLs
 - DOMPurify on all user-generated content rendering
+
+## Local Development & Testing Infrastructure
+
+Shared dev infrastructure is available for running tests, builds, and local dev.
+
+### Database Access
+
+- **PostgreSQL 16**: host `singi-labs-postgres-1`, port `5432`, user `singi`, password `singi-dev`
+  - `barazo_dev` -- for local dev server
+  - `barazo_test` -- for test runs (wiped between test suites)
+- **Valkey 8**: host `singi-labs-valkey-1`, port `6379` (no auth)
+
+### Environment Setup
+
+Create a `.env` file in the repo CWD before running tests or dev:
+
+```env
+# /singi-labs/repos/barazo-web/.env
+DATABASE_URL=postgres://singi:singi-dev@singi-labs-postgres-1:5432/barazo_dev
+VALKEY_URL=redis://singi-labs-valkey-1:6379
+```
+
+For integration tests, use `barazo_test` to avoid polluting dev data:
+
+```env
+DATABASE_URL=postgres://singi:singi-dev@singi-labs-postgres-1:5432/barazo_test
+VALKEY_URL=redis://singi-labs-valkey-1:6379
+```
+
+### First-Time Setup
+
+Before running any commands, install dependencies (only needed once -- `node_modules` persists across heartbeats):
+
+```sh
+pnpm install
+```
+
+### Available Commands
+
+- `pnpm lint` -- ESLint
+- `pnpm typecheck` -- TypeScript strict check
+- `pnpm build` -- compile
+- `pnpm test` -- unit tests (Vitest)
+- `pnpm test:integration` -- integration tests (needs `DATABASE_URL` + `VALKEY_URL`)
+- `pnpm test:coverage` -- unit tests with coverage report
+
+### Mandatory Before Pushing
+
+Every agent MUST run this before pushing a branch:
+
+```sh
+pnpm lint && pnpm typecheck && pnpm build && pnpm test
+```
+
+Fix failures before pushing. Never push broken code.
+
+### VPS Access
+
+Agents can SSH to the staging server for deployment and debugging:
+
+- `ssh barazo-staging` -- connects as deploy user
+- No passwordless sudo on staging -- use for docker commands and log inspection only

--- a/agents-md/shared.md
+++ b/agents-md/shared.md
@@ -34,6 +34,8 @@ The GitHub board may lag behind actual implementation state. Partial or complete
 
 All changes go through Pull Requests -- never commit directly to `main`. Branch naming: `type/short-description` (e.g., `feat/add-reactions`, `fix/xss-sanitization`).
 
+**No AI attribution in commits or PRs.** Never include "Generated with Claude Code", "Co-Authored-By: Claude", or any AI tool attribution in commit messages, PR titles, or PR bodies.
+
 **Use git worktrees for all feature work.** Each branch must get its own working directory. This prevents multiple agents from stepping on each other's files and allows parallel work without stashing.
 
 ```bash


### PR DESCRIPTION
## Summary

- Add explicit rule to `shared.md` (propagated to all repo AGENTS.md via build): never include "Generated with Claude Code", "Co-Authored-By: Claude", or any AI tool attribution in commit messages, PR titles, or PR bodies
- Addresses reported issue where PRs were including the Claude Code footer attribution

## Test plan
- [ ] CI checks pass
- [ ] `agents-md/shared.md` contains the no-attribution rule under Git Workflow
- [ ] `bash agents-md/build.sh` produces dist files that include the rule

Fixes singi-labs/barazo-workspace#19