### PR TITLE
fix(agents-md): substitute <repo> placeholder with actual repo name

### DIFF
--- a/agents-md/build.sh
+++ b/agents-md/build.sh
@@ -12,10 +12,12 @@ for repo_file in "$REPOS_DIR"/*.md; do
   repo_name="$(basename "$repo_file" .md)"
   output="$OUTPUT_DIR/$repo_name.md"
 
-  # Concatenate: repo-specific header + separator + shared base
+  # Concatenate: repo-specific header + separator + shared base.
+  # Substitute <repo> placeholders in shared.md with the actual repo name so
+  # rendered commands and paths are directly runnable per repo.
   cat "$repo_file" > "$output"
   printf '\n---\n\n' >> "$output"
-  cat "$SHARED" >> "$output"
+  sed "s/<repo>/$repo_name/g" "$SHARED" >> "$output"
 
   echo "Built: $output"
 done


### PR DESCRIPTION
## Summary
- Substitute `<repo>` in `shared.md` with the per-repo name during sync, so rendered AGENTS.md commands are directly runnable.
- One-line `sed` change in `agents-md/build.sh`. No content changes to `shared.md` needed.

## Why
CodeRabbit flagged this on `barazo-api#226` (sync PR): commands like `gh pr list --repo singi-labs/<repo>` aren't runnable when copy/pasted, risking contributor error.

## Test plan
- [x] Rebuilt locally — `<repo>` count in `dist/barazo-api.md` went from 6 to 0
- [x] Verified commands now read `singi-labs/barazo-api` etc.
- [ ] After merge, sync workflow auto-triggers on push to `agents-md/**` → new sync PRs land clean → close the stale sync PRs from 2026-05-18 and 2026-05-25